### PR TITLE
Fixed long-option argument parsing

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -91,8 +91,8 @@ do
 	a) auto_detect_wm=true;;
 	m) monitor_aware=true;;
 	-)
-		OPTION=$(echo "$OPTARG" | awk -F '=' '{print $1}')
-		OPTARG=$(echo "$OPTARG" | awk -F '=' '{print $2}')
+		OPTION=${OPTARG%%=*}
+		OPTARG=${OPTARG#*=}
 		case $OPTION in
 		height) height=$OPTARG;;
 		width) width=$OPTARG;;

--- a/tdrop
+++ b/tdrop
@@ -225,7 +225,7 @@ update_geometry_settings_for_monitor() {
 	local last_monitor
 	last_monitor=$(< /tmp/tdrop/last_monitor)
 	echo "$current_monitor" > /tmp/tdrop/last_monitor
-	if [[ $current_monitor != $last_monitor ]]; then
+	if [[ $current_monitor != "$last_monitor" ]]; then
 		monitor_changed=true
 	fi
 }

--- a/tdrop
+++ b/tdrop
@@ -438,12 +438,7 @@ maybe_cancel_auto_show() {
 #
 
 term_create() {
-	local term_command
-	if [[ -n $program_flags ]]; then
-		term_command="$term $program_flags"
-	else
-		term_command=$term
-	fi
+	local term_command="$term $program_flags"
 	if [[ $term == terminix ]]; then
 		sleep_term_time=0.3
 	fi
@@ -471,12 +466,7 @@ term_create() {
 }
 
 win_create() {
-	local win_command
-	if [[ -n $program_flags ]]; then
-		win_command="$term $program_flags"
-	else
-		win_command=$term
-	fi
+	local win_command="$term $program_flags"
 	$win_command &
 	# need to wait for window to be created
 	sleep $sleep_win_time


### PR DESCRIPTION
Arguments of long-options (e.g. --program-flags='--foo=bar') may contain
equal sign characters (=). Before this fix, these kind of options were
split up into "program-flags" and "--foo" removing the last part of the
argument. This was because only the first two colums from `awk -F= ...`
were used.

Now these kind of options will be split up correctly using Bash parameter
expansion: "program-flags" and "--foo=bar".

See man bash > Parameter Expansion for details.

Tested with:
```
sudo cp tdrop /usr/bin/tdrop
tdrop -W --program-flags='-e tmux --role=tdropwindow'   termite
tdrop -W              -f '-e tmux --role=tdropwindow'   termite
tdrop --normal-window -f '-e tmux --role=tdropwindow'   termite
```

It also works for boolen long-option flags without argument. In this
case both OPTION and OPTARG are set to the long-option name. Boolean
options don't use the OPTARG so it doesn't matter.

-------------

I hope you like the refactoring? I think it would be a good application of the KISS principle.

PS: Thank you. I love your program!