### PR TITLE
Fix in documentation

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -21,7 +21,7 @@ options:
 	-M cmd       provide a post-unmap command; can be used for example with a window manager that doesn't support floating to turn fullscreen on when mapping a terminal then off when unmapping it
 	-O cmd       provide a one time command only for when a dropdown is created/initiated (useful for 'tdrop current')
 	-d XxY       give decoration/border size to accurately save position; only applicable with auto_show; on applicable with a few window managers (e.g. blackbox)
-	-f           specify flags/options to be used when creating the term or window (e.g. -f '--title mytitle', default: none)
+	-f           specify flags/options to be used when creating the term or window (e.g. -f '--title mytitle'; default: none). caution: if there is a tmux/tmuxinator session specified (with -s), the option to execute a program (usually -e for terminal programs) is implicitly added by tdrop!
 	-a           automatically detect window manager and if settings exist for it, automatically set -p, -P, and -d values as necessary; this can have affect when used with a terminal or with auto_show or auto_hide (default: false)
 	-m           for use with multiple monitors and only with dropdowns (not for auto_show or auto_hide); convert percentages used for width or height to values relative to the size of the current monitor and force reszing of the dropdown when the monitor changes (default: false)
 	--clear      clear saved window id; useful accidentally make a window a dropdown (e.g. '$ tdrop --clear current')

--- a/tdrop.groff
+++ b/tdrop.groff
@@ -52,7 +52,7 @@ Specify a post command to execute only when first creating or initiating a dropd
 Specify a window decoration/border size in the form <x decoration size>x<y decoration size> to be taken into account when saving window position. This should not be necessary for most window managers and is only used with 'auto_show', e.g. 'tdrop -d 1x22 auto_show' for blackbox. (default: none)
 .TP
 \fB\-f\fR, \fB \-\-program-flags\fR
-Specify flags/options that the terminal or program should be called with. For example, to set the title of the terminal, something like '-f "--title mytitle"' can be used. (default: none)
+Specify flags/options that the terminal or program should be called with. For example, to set the title of the terminal, something like '-f "--title mytitle"' can be used. Caution: If there is a tmux/tmuxinator session specified (with -s), the option to execute a program (usually -e for terminal programs) is implicitly added by tdrop! (default: none)
 .TP
 \fB\-a\fR, \fB \-\-auto-detect-wm\fR
 If there are available settings for the detected window manager for the -p, -P, -M, and/or -d options, automatically set them; takes no argument. User set settings will still override these. This can be used with 'tdrop <terminal>', 'tdrop auto_hide', and 'tdrop auto_show'. For 'auto_hide', if the window manager is supported, it will check if the current window is tiled so that it is not changed to floating when auto-showing. (default: false)


### PR DESCRIPTION
I added a clarifying sentence to the documentation. Hope that helps other users.

The fact that `-e ...` was a "hidden" option passed to the specified program was not obvious. For example I struggled because my terminal didn't startet up with tmux although I specified that as `--program-flags`:

```
tdrop -f '-e tmux' termite
```

Now it should be more clear.