### PR TITLE
Add auto detect support for urxvt256c-ml

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -358,6 +358,8 @@ set_class() {
 			class=Gnome-terminal
 		elif [[ $program == urxvtc ]]; then
 			class=urxvt
+		elif [[ $program == urxvt256c-ml ]]; then
+			class=URxvt
 		elif [[ $program == xiatec ]]; then
 			class=xiate
 		elif [[ $program == alacritty ]]; then


### PR DESCRIPTION
Fedora have many different urxvt packages with different features. This one is the 256 color version with "multi language" support.

By the way, there's also a problem with the class names on my Fedora system. The -a option will not work unless I write URxvt with "UR" in uppercase.

Maybe force the class to lower case?

This is what xprop shows:

```
WM_CLASS(STRING) = "urxvt256c-ml", "URxvt"
WM_CLASS(STRING) = "urxvt", "URxvt"
```

In any case, the workaround for bspwm is something like this:
```
super + t
	tdrop -p "bspc rule -a URxvt -o state=floating" -w 33% -y 25% -x 33% urxvt256c-ml
```