### PR TITLE
Add workaround for flatpak

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,6 +78,18 @@ Some window managers allow querying what the current monitor is (e.g. bspwm and 
 
 See the manpage for more information.
 
+** Flatpak
+
+As [[https://www.flatpak.org/][Flatpak]] jails applications, the PID cannot be used to find the attached window. A class name has to be given in order to find it, with =--class=.
+
+As Flatpak is considered by tdrop as the program to run, tdrop cannot differentiate 2 different flatpak applications. Use the =-n= option for this purpose.
+
+Example:
+#+BEGIN_EXAMPLE
+tdrop -ma -n signal --class=signal flatpak run org.signal.Signal
+tdrop -ma -n firefox --class=firefox flatpak run org.mozilla.firefox
+#+END_EXAMPLE
+
 ** Flicker
 For some window managers that require a window to be repositioned after re-mapping it, some flicker may be noticeable. This flicker has been mostly fixed for some window managers (e.g. in the Gnome Shell and Cinnamon DEs) and improved for others. It is usually worse on tiling managers where the window must be re-floated every time it is mapped. The way around this is to use rules to either always have the class or name (see =--name=) floated or one-time rules to only float the next instance of a class. For example, since bspwm has oneshot rules and generally doesn't alter the size/position of a window, there isn't any movement flicker.
 

--- a/tdrop
+++ b/tdrop
@@ -412,6 +412,10 @@ set_class() {
 			class=xiate
 		elif [[ $program == alacritty ]]; then
 			class=Alacritty
+		elif [[ $program == flatpak ]]; then
+			# flatpak jails the application, the PID cannot be used to find
+			# the window. A specific class has to be given by the user.
+			error "--class is required with flatpak but was not given."
 		elif [[ $program == current ]]; then
 			class=$(cat "$MUTDROP_PATH"/current"$num"_class  2> /dev/null)
 		else
@@ -609,6 +613,8 @@ create_win_return_wid() {
 			wids=$(xdotool search --classname qutebrowser)
 		elif [[ $program =~ ^emacsclient ]]; then
 			wids=$(xdotool search --classname emacs)
+		elif [[ $program == flatpak ]]; then
+			wids=$(xdotool search --classname "$class")
 		else
 			wids=$(xdotool search --pid "$pid")
 		fi


### PR DESCRIPTION
Flatpak jails applications, so the PID cannot be used to find the associated window.

It adds a workaround to get the wid using the classname given as input when flatpak is used. Therefore, it also requires a classname to be given to tdrop when running a flatpak.