### PR TITLE
Bugfix: gsub("+*","") -> gsub("+.*","")

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -717,7 +717,7 @@ wid_toggle() {
 	# deal with percentages/negatives when no -m
 	if ! $monitor_aware; then
 		local total_geo total_width total_height
-		total_geo=$(xwininfo -root | gawk '/geometry/ {gsub("+*",""); print $2}')
+		total_geo=$(xwininfo -root | gawk '/geometry/ {gsub("+.*",""); print $2}')
 		# total_width=$(echo "$total_geo" | gawk -F 'x' '{print $1}')
 		total_width=${total_geo%x*}
 		# total_height=$(echo "$total_geo" | gawk -F 'x' '{print $2}')


### PR DESCRIPTION
Without this fix the window height is reported incorrectly unless monitor_aware is true, because only the '+'s will be removed from the xwininfo output and the x & y offsets will be left appended to the geometry.