### PR TITLE
Fixes position of tdrop in the current window

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -290,7 +290,7 @@ update_geometry_settings_for_monitor() {
 	elif [[ $wm == i3 ]]; then
 		# TODO use jq if installed
 		# I'd rather not make jq a dependency
-		current_monitor=$(i3-msg -t get_workspaces | sed 's/{"num"/\n/g' | \
+		current_monitor=$(i3-msg -t get_workspaces | sed 's/"num"/\n/g' | \
 							  gawk -F ',' '/focused":true/ {sub(".*output",""); gsub("[:\"]",""); print $1}')
 	fi
 


### PR DESCRIPTION
Looks like the i3 command get_workspaces has changed.
Now the output is like: [{"id":94139558072976,"num":3,"name":"3","visible":true
So '{"num' does not match and gawk selects the incorrect window.

Simply fix to break the json in the "num".

Fixes #82 