### PR TITLE
Fix setting position when -x, -y empty

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -347,23 +347,23 @@ update_geometry_settings_for_monitor() {
 
 	# update x and y offsets, so that will appear on correct screen
 	# (required for some WMs apparently, but not for others)
-	((xoff+=x_begin))
-	((yoff+=y_begin))
+	[[ -n $xoff ]] && ((xoff+=x_begin))
+	[[ -n $yoff ]] && ((yoff+=y_begin))
 }
 
 map_and_reset_geometry() {
 	if [[ -n $width ]] && [[ -n $height ]] && [[ -n $xoff ]] \
 		   && [[ -n $yoff ]]; then
-		xdotool windowmap "$wid" windowmove "$wid" "$xoff" "$yoff" \
+		xdotool windowmap "$wid" windowactivate "$wid" windowmove "$wid" "$xoff" "$yoff" \
 				windowsize "$wid" "$width" "$height" 2> /dev/null
 	elif [[ -n $width ]] && [[ -n $height ]]; then
-		xdotool windowmap "$wid" windowsize "$wid" "$width" "$height" \
+		xdotool windowmap "$wid" windowactivate "$wid" windowsize "$wid" "$width" "$height" \
 				2> /dev/null
 	elif [[ -n $xoff ]] && [[ -n $yoff ]]; then
-		xdotool windowmap "$wid" windowmove "$wid" "$xoff" "$yoff" \
+		xdotool windowmap "$wid" windowactivate "$wid" windowmove "$wid" "$xoff" "$yoff" \
 				2> /dev/null
 	else
-		xdotool windowmap "$wid" 2> /dev/null
+		xdotool windowmap "$wid" windowactivate "$wid" 2> /dev/null
 	fi
 }
 
@@ -753,8 +753,6 @@ wid_toggle() {
 			xdotool set_desktop_for_window "$wid" "$(xdotool get_desktop)"
 			if [[ $(get_visibility "$wid") == IsUnMapped ]]; then
 				pre_map
-			else
-				xdotool windowactivate "$wid"
 			fi
 			# update here if possible so this doesn't cause a delay
 			# between the window being remapped and resized


### PR DESCRIPTION
This fixes a couple of the issues I mentioned in https://github.com/noctuid/tdrop/issues/70#issuecomment-875794600

> There is also a strange case with -A; if the window is hidden then the shortcut brings the window to the front and focuses it. Pressing the shortcut a second time does nothing, even though it should hide the window (since it's focused). Pressing the shortcut a third time does hide window.

Modifying `map_and_reset_geometry` to unconditionally call `windowactivate` after `windowmap` seems to fix this issue... I'm uncertain how this might conflict with `-A` or similar options but I don't think it will. If you're mapping the window, you'd always want it focused too, right?

Edit: I have a hunch this may have side-effects regarding https://github.com/noctuid/tdrop/issues/335; the triple-press behavior sounds similar to what's described there.

Edit: I'm also unsure if this may conflict with behavior from map and create hooks. Again, I don't _think_ it will, but I'm not too familiar with them.

> The window appears in the top-left regardless of context.

This is caused by these lines overriding the values `xoff` and `yoff`. Conditionally executing these preserves empty values, so the conditions in `map_and_reset_geometry` are evaluated correctly.

https://github.com/noctuid/tdrop/blob/fad32b6b1c87c5989cafad6af85e789e4f67946c/tdrop#L350-L351

_However_ this does not necessarily make the window "remember" its position; it simply doesn't reset the position every time, deferring placement behavior to the WM. Gnome 3/mutter seems to place the window somewhere vaguely in the top-left; gnome-tweaks lets me enable "center new windows", in which case the window is always centered. I expect a tiling manager would place the window in a tile.

For me, the question now becomes "how do I get Gnome/mutter to remember a window position after an unmap-remap?". As far as I can tell there's not really a way to do this. Using gnome-tweaks to enable "center new windows" is suitable to me for now until I figure out a better solution.