### PR TITLE
Use "xdotool getwindowfocus"

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -319,7 +319,7 @@ update_geometry_settings_for_monitor() {
 		if ! $pointer_monitor_detection; then
 			# determine current monitor using active window
 			local wid wininfo
-			wid=$(xdotool getactivewindow)
+			wid=$(xdotool getwindowfocus)
 			if [[ -z $wid ]]; then
 				# will try again after remapping or creating the dropdown
 				return 1
@@ -703,7 +703,7 @@ program_start() {
 current_create() {
 	# turns active window into a dropdown
 	local wid
-	wid=$(xdotool getactivewindow)
+	wid=$(xdotool getwindowfocus)
 	echo "$wid" > "$MUTDROP_PATH"/current"$num"
 	get_class_name "$wid" > "$MUTDROP_PATH"/current"$num"_class
 	if [[ -n $name ]]; then
@@ -751,7 +751,7 @@ wid_toggle() {
 	fi
 	if $exists; then
 		if [[ $visibility =~ ^(IsUnMapped|IsUnviewable)$ ]] \
-			   || $always_activate  && [[ $(xdotool getactivewindow) != $wid ]]
+			   || $always_activate  && [[ $(xdotool getwindowfocus) != $wid ]]
 		then
 			# visibility will be IsUnMapped on most WMs if the dropdown is open
 			# on another desktop; may also be IsUnviewable
@@ -839,9 +839,9 @@ get_geometry() {
 				y=$((y-rel_y))
 			fi
 		fi
-		width=$(xwininfo -id "$(xdotool getactivewindow)" | \
+		width=$(xwininfo -id "$(xdotool getwindowfocus)" | \
 					gawk '/Width/ {print $2}')
-		height=$(xwininfo -id "$(xdotool getactivewindow)" | \
+		height=$(xwininfo -id "$(xdotool getwindowfocus)" | \
 					 gawk '/Height/ {print $2}')
 		echo -n -e "xoff=$x\nyoff=$y\nwidth=$width\nheight=$height"
 	else
@@ -879,7 +879,7 @@ auto_hide() {
 	local no_hide
 	no_hide=$(cat "$MUTDROP_PATH"/auto_hidden/no_hide 2> /dev/null)
 	if [[ -z $no_hide ]]; then
-		wid=$(xdotool getactivewindow)
+		wid=$(xdotool getwindowfocus)
 		mkdir -p "$MUTDROP_PATH"/auto_hidden
 		echo "$wid" > "$MUTDROP_PATH"/auto_hidden/wid
 		get_class_name "$wid" > "$MUTDROP_PATH"/auto_hidden/class


### PR DESCRIPTION
Recently I noticed that tdrop is unable to show dropdown terminal on an empty desktop (i. e. when all windows are minimized or when there's no windows at all) because of this:

```
XGetWindowProperty[_NET_ACTIVE_WINDOW] failed (code=1)
xdo_get_active_window reported an error
```

Zsh-notify once successfully merged [fix](https://github.com/marzocchi/zsh-notify/pull/75) for this bug. On my machine problem indeed was solved simply by replacing "xdotool getactivewindow" with "xdotool getwindowfocus" ("getwindowfocus" doesn't return error if no window is active).

I hope this will not break anything.