### PR TITLE
Fix activation window on another desktop - bspwm. issue #369

### DIFF
--- a/README.org
+++ b/README.org
@@ -187,7 +187,7 @@ alias gc='hide_on_open git commit'
 The most useful application of this functionality is probably when opening videos, images, etc. in an external program from a file manager like ranger. For example, in the =rifle.conf=:
 
 #+BEGIN_EXAMPLE
-mime ^video, has mpv, X, flag f = tdrop -a auto_hide && mpv -- "$@" && tdrop -a auto_show
+mime ^video, has mpv, X, flag f = tdrop -a auto_hide ; mpv -- "$@" && tdrop -a auto_show
 #+END_EXAMPLE
 
 ** Other Commands

--- a/tdrop
+++ b/tdrop
@@ -454,7 +454,9 @@ map_and_reset_geometry() {
 	# windowmap does not activate for all window managers; windowactivate should
 	# be run separately or can activate window on another desktop on some window
 	# managers (e.g. bspwm)
-	# xdotool windowactivate "$wid" 2> /dev/null # THIS BROKEN BSPWM
+	if [[ $wm != bspwm ]]; then
+	    xdotool windowactivate "$wid" 2> /dev/null
+	fi
 }
 
 # * WM Detection and Hooks

--- a/tdrop
+++ b/tdrop
@@ -454,7 +454,7 @@ map_and_reset_geometry() {
 	# windowmap does not activate for all window managers; windowactivate should
 	# be run separately or can activate window on another desktop on some window
 	# managers (e.g. bspwm)
-	xdotool windowactivate "$wid" 2> /dev/null
+	# xdotool windowactivate "$wid" 2> /dev/null # THIS BROKEN BSPWM
 }
 
 # * WM Detection and Hooks


### PR DESCRIPTION
"windowactivate can activate window on another desktop on some window managers (e.g. bspwm)"

 Added a simple check: is NOT bspwm