### PR TITLE
Add support for wezterm (-s)

### DIFF
--- a/README.org
+++ b/README.org
@@ -222,6 +222,7 @@ These terminals have been tested with tdrop and support the =-s= and =-a= flags 
 - Tilix (previously terminix)
 - tinyterm/minyterm
 - URxvt (including urxvtd)
+- Wezterm
 - Xfce4-terminal (XFCE)
 - xiate
 - XTerm

--- a/tdrop
+++ b/tdrop
@@ -931,6 +931,8 @@ program_start() {
 			program_command+=(-e bash -c "$tmux_command")
 		elif [[ $program == kitty ]]; then
 			program_command+=(bash -c "$tmux_command")
+		elif [[ $program == wezterm || $class == wezterm ]]; then
+			program_command+=(start -- bash -c "$tmux_command")
 		else
 			program_command+=(-e "bash -c '$tmux_command'")
 		fi


### PR DESCRIPTION
I tested it on my system (Wezterm installed as flatpak) and it works as long as we set the --class to `wezterm`.

