### PR TITLE
Add information about Wayland support to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -85,6 +85,16 @@ Some window managers allow querying what the current monitor is or directly for 
 
 See the manpage for more information.
 
+** Wayland support
+Tdrop does not support programs that use Wayland directly, but it does work under Wayland if the program uses XWayland. If your program defaults to using Wayland, you can generally force it to use XWayland by setting the environment variable =WAYLAND_DISPLAY=no=.
+
+Also note that certain tdrop features don't work under Wayland due to limitations of =xdotool=. For instance, =-m= / =--monitor-aware= only works when combined with =-t= / =--pointer-monitor-detection=.
+
+Example:
+#+begin_example
+WAYLAND_DISPLAY=no tdrop -mta alacritty
+#+end_example
+
 ** Flatpak
 As [[https://www.flatpak.org/][Flatpak]] jails applications, the PID cannot be used to find the attached window. A class name has to be given in order to find it, with =--class=.
 


### PR DESCRIPTION
It took me a while to make Alacritty work with tdrop again after the Alacritty devs added native Wayland support. Hopefully this information will make it easier for others facing the same problems.

Side note: The errors I got when just running `tdrop -ma alacritty` were rather confusing:
```
XGetWindowProperty[_NET_ACTIVE_WINDOW] failed (code=1)
xdo_get_active_window reported an error
gawk: cmd. line:1: BEGIN {printf("%.0f", 0.01*100*)}
gawk: cmd. line:1:                               ^ syntax error
gawk: cmd. line:1: BEGIN {printf("%.0f", 0.01*45*)}
gawk: cmd. line:1:                               ^ syntax error
2023-02-08 12:22:22 Error: Exceeded timeout of 10 seconds waiting for program.
```
It turned out this was because `xdotool getactivewindow` fails when the active window is using Wayland, which leads to the monitor dimensions being unset if monitor-aware mode is enabled. @noctuid perhaps this failure mode could be handled better?