### PR TITLE
Fix for Wezterm dropdown toggle failing to work whenever it spawns a new process.

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -870,6 +870,9 @@ create_win_return_wid() {
 						<(xdotool search --role 'browser-window' | sort))
 		elif [[ $program == strawberry ]]; then
 			wids=$(xdotool search --all --pid "$pid" --name "Strawberry Music Player")
+		elif [[ $program == wezterm ]]; then
+			# Refresh Wezterm wids in case our window belongs to a newly spawned process
+			wids=$(xdotool search --classname wezterm)
 		else
 			wids=$(xdotool search --pid "$pid")
 		fi


### PR DESCRIPTION
When Wezterm is launched with a custom configuration path (for example: `wezterm --config-file="$HOME/.config/wezterm/wezterm.dropdown.lua"`) it causes the new instance to be launched in a new process.

Other options, such as setting a custom `class`/`window` names also cause Wezterm to create a new process instead of reusing the existing one.

On latest Git version of `tdrop` this causes timeout errors combined with duplicate dropdowns being spawned on toggle, as long as there is a Wezterm instance running in the background.

This seems to have been caused by [this commit](https://github.com/noctuid/tdrop/commit/1e2f3953405169036ae7e8760b0a6f73685a79f0).

#### Steps to reproduce:
- Open `wezterm` (settings/environment don't matter)
- Run `tdrop wezterm --config-file="$HOME/.config/wezterm/wezterm.lua"` (you can also point it to the main configuration or run `trdop wezterm start --always-new-process` to replicate the same issue, since all of these commands force wezterm to run in a new process)
- In 10 seconds there will be errors about a timeout. Rerunning the above tdrop command will cause new dropdown windows to open.

#### Workarounds

Commenting out (https://github.com/noctuid/tdrop/blob/master/tdrop#L810) fixes the issue but breaks the behavior for `wezterm` instances running in the same process.

Keep in mind that it takes a while for the new Wezterm process to spawn, so when running `pgrep` at that line, only the already existing PID gets captured, not the new one.

## The possible fix

The change in this PR fixes the problem on my end, without breaking the behavior for single-process Wezterm instances.
That being said I'm not sure if this is the best solution in this case.