### PR TITLE
gnome-terminal fixes

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -836,15 +836,15 @@ create_win_return_wid() {
 	visible_wid=false
 	counter=0
 	while : ; do
-		if [[ $program == gnome-terminal ]]; then
-			# only 1 pid; changes at some point after first run
-			# actual process name for me is gnome-terminal-
-			pid=$(pgrep gnome-terminal)
-		fi
 		if ((counter==0)); then
 			debug "pid: $pid"
 		fi
-		if [[ $program == discord ]]; then
+		if [[ $program == gnome-terminal ]]; then
+			wids=""
+			for pid in $(pgrep gnome-terminal); do
+				wids+=$(xdotool search --pid "$pid")
+			done
+		elif [[ $program == discord ]]; then
 			wids=$(xdotool search --classname discord)
 			blacklist=
 		elif [[ $program =~ ^(qutebrowser|brave|spotify|wezterm)$ ]]; then

--- a/tdrop
+++ b/tdrop
@@ -947,6 +947,8 @@ program_start() {
 			program_command+=(bash -c "$tmux_command")
 		elif [[ $program == wezterm || $class =~ ^(org\.wezfurlong\.)?wezterm$ ]]; then
 			program_command+=(start -- bash -c "$tmux_command")
+		elif [[ $program == gnome-terminal ]]; then
+			program_command+=(-- bash -c "$tmux_command")
 		else
 			program_command+=(-e "bash -c '$tmux_command'")
 		fi


### PR DESCRIPTION
This fixes two issues with `gnome-terminal`:

1. `pgrep gnome-terminal` would return multiple `pids`, so simply doing `xdotool search --pid $pid` would not work.  Instead, this changes `tdrop` to search all the `pids` returned by `pgrep` for any `wids`.

2. With at least `gnome-terminal 3.44`, the `-e command` argument is deprecated, so use `-- command` as suggested by `gnome-terminal` instead.

With this, I can successfully use `tdrop` with `gnome-terminal`.  Otherwise, running `tdrop gnome-terminal` would just keep spawning new windows and would not work at all.