### PR TITLE
Fix invalid regexp in total_geo by escaping `+`

### DIFF
--- a/tdrop
+++ b/tdrop
@@ -986,7 +986,7 @@ wid_toggle() {
 	# deal with percentages/negatives when no -m
 	if ! $monitor_aware; then
 		local total_geo total_width total_height
-		total_geo=$(xwininfo -root | gawk '/geometry/ {gsub("+.*",""); print $2}')
+		total_geo=$(xwininfo -root | gawk '/geometry/ {gsub("\\+.*",""); print $2}')
 		# total_width=$(echo "$total_geo" | gawk -F 'x' '{print $1}')
 		total_width=${total_geo%x*}
 		# total_height=$(echo "$total_geo" | gawk -F 'x' '{print $2}')


### PR DESCRIPTION
The regex used in `total_geo` results in the follow error:
```
gawk: cmd. line:1: (FILENAME=- FNR=23) fatal: invalid regexp: ? * + or {interval} not preceded by valid subpattern: /+.*/
gawk: cmd. line:1: BEGIN {printf("%.0f", 0.01*80*)}
gawk: cmd. line:1:                               ^ syntax error
gawk: cmd. line:1: BEGIN {printf("%.0f", 0.01*55*)}
gawk: cmd. line:1:                               ^ syntax error
gawk: cmd. line:1: BEGIN {printf("%.0f", 0.01*10*)}
gawk: cmd. line:1:                               ^ syntax error
```
Which causes the window to not resize or position itself correctly.

This is easily fixed by escaping the `+` twice.